### PR TITLE
utf-8 and indexing bugs

### DIFF
--- a/src/wield/utilities/file_io/pickle_io.py
+++ b/src/wield/utilities/file_io/pickle_io.py
@@ -11,7 +11,7 @@ import pickle
 
 
 def load_pickle(fname):
-    with open(fname) as F:
+    with open(fname, "rb") as F:
         fdict = pickle.load(F)
     return fdict
 

--- a/src/wield/utilities/np.py
+++ b/src/wield/utilities/np.py
@@ -129,7 +129,7 @@ def continuous_phase(data, op_idx=0, sep=(1.01) * np.pi, deg=False, shiftmod=2):
     while raw_angle[op_idx] > np.pi:
         raw_angle -= 2 * np.pi
 
-    median = np.sort(raw_angle)[len(raw_angle) / 2]
+    median = np.sort(raw_angle)[int(len(raw_angle) / 2)]
     if median < -np.pi / 4:
         raw_angle += np.pi * 2
 


### PR DESCRIPTION
Fixes two minor bugs
1. a utf-8 bug when using `pickle_io.load_pickle`
2. an indexing bug in `np.continuous_phase`