### PR TITLE
no copying in write_any

### DIFF
--- a/src/wield/utilities/file_io/any_io.py
+++ b/src/wield/utilities/file_io/any_io.py
@@ -213,22 +213,23 @@ def write_any(
     fdict,
 ):
     features = types.type2features[ftype]
-    fdict_orig = None
+    # fdict_orig = None
 
-    if fdict_orig is None:
-        fdict_orig = fdict
-        fdict = copy.deepcopy(fdict)
+    # if fdict_orig is None:
+    #     fdict_orig = fdict
+    #     fdict = copy.deepcopy(fdict)
     cull_None(fdict)
     if not features["complex"]:
         if fdict_orig is None:
             fdict_orig = fdict
-            fdict = copy.deepcopy(fdict)
+            # fdict = copy.deepcopy(fdict)
         fix_complex_write(fdict)
 
     if not features["ndarray"]:
-        if fdict_orig is None:
+        # if fdict_orig is None:
+        if not features["complex"]:
             fdict_orig = fdict
-            fdict = copy.deepcopy(fdict)
+            # fdict = copy.deepcopy(fdict)
         fix_ndarray(fdict)
 
     if ftype == "hdf5":

--- a/src/wield/utilities/file_io/any_io.py
+++ b/src/wield/utilities/file_io/any_io.py
@@ -220,16 +220,15 @@ def write_any(
     #     fdict = copy.deepcopy(fdict)
     cull_None(fdict)
     if not features["complex"]:
-        if fdict_orig is None:
-            fdict_orig = fdict
-            # fdict = copy.deepcopy(fdict)
+        # if fdict_orig is None:
+        #     fdict_orig = fdict
+        #     fdict = copy.deepcopy(fdict)
         fix_complex_write(fdict)
 
     if not features["ndarray"]:
         # if fdict_orig is None:
-        if not features["complex"]:
-            fdict_orig = fdict
-            # fdict = copy.deepcopy(fdict)
+        #     fdict_orig = fdict
+        #     fdict = copy.deepcopy(fdict)
         fix_ndarray(fdict)
 
     if ftype == "hdf5":


### PR DESCRIPTION
This changes the logic in `write_any` so that the dict to be saved is never copied or deepcopied since not all objects have `__copy__` and `__deepcopy__` methods.

This could potentially be simplified. Previously there was a variable `fdict_orig` whose only function, in practice, was to check if there were complex features in `fdict`. While the original `fdict` was getting deepcopied, I didn't see anywhere where this was important.

Note that `load_any` also has a variable `fdict_orig` that doesn't do anything at all. So maybe these are a holdover from some old code or maybe I'm missing something.