### PR TITLE
fix matplotlib keyword bugs

### DIFF
--- a/src/wield/utilities/mpl/autoniceplot.py
+++ b/src/wield/utilities/mpl/autoniceplot.py
@@ -417,8 +417,8 @@ def mplfigB(
                 ax.set_prop_cycle(color=prop_cycle)
             # patch_axes(ax)
             ax_list.append(ax)
-            ax.grid(b=True)
-            ax.grid(b=True, which="minor", color=(0.9, 0.9, 0.9), lw=0.5)
+            ax.grid(visible=True)
+            ax.grid(visible=True, which="minor", color=(0.9, 0.9, 0.9), lw=0.5)
             axB.ax_grid_colrow[idx_col].append(ax)
             axB["ax{0}_{1}".format(idx_row, idx_col)] = ax
             axB["ax{0}".format(N)] = ax

--- a/src/wield/utilities/mpl/stacked_plots.py
+++ b/src/wield/utilities/mpl/stacked_plots.py
@@ -131,8 +131,8 @@ def generate_stacked_plot_ax(
         for idx, name in enumerate(view_names):
             ax_local = fig.add_subplot(gs_DC[idx, col_idx], sharex=ax_top)
             # patch_axes(ax_local)
-            ax_local.grid(b=True)
-            ax_local.grid(b=True, which="minor", color=(0.9, 0.9, 0.9), lw=0.5)
+            ax_local.grid(visible=True)
+            ax_local.grid(visible=True, which="minor", color=(0.9, 0.9, 0.9), lw=0.5)
             axB["ax{0}_{1}".format(idx, col_idx)] = ax_local
             if col_idx == 0:
                 axB["ax{0}".format(idx)] = ax_local


### PR DESCRIPTION
changed the "b" keyword in grid to "visible" since "b" is deprecated.

wield.model also uses these functions and so this is breaking some of the mode-matching functionality.